### PR TITLE
Adding some environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - '3.3'
   - '3.4'
   - '3.5'
   - '3.6'

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ ADD dist/docker_hostdns-${HOSTDNS_VERSION}-py3-none-any.whl /usr/local/share/
 RUN pip install /usr/local/share/docker_hostdns-${HOSTDNS_VERSION}-py3-none-any.whl \
     && rm -rf /root/.cache
 
+VOLUME ["/run/docker.sock"]
+
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,4 @@ ADD dist/docker_hostdns-${HOSTDNS_VERSION}-py3-none-any.whl /usr/local/share/
 RUN pip install /usr/local/share/docker_hostdns-${HOSTDNS_VERSION}-py3-none-any.whl \
     && rm -rf /root/.cache
 
-VOLUME ["/run/docker.sock"]
-
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
-

--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ Build image from GitHub
 - ``python3 setup.py bdist_wheel``
 - ``docker build -t "<image name>" --build-arg HOSTDNS_VERSION=<version> .``
 
-* <version> ``2.1.0`` is the latest at the time of writing. The version is visible in the output of ``python3 setup.py bdist_wheel``, e.g.:
+<version> ``2.1.0`` is the latest at the time of writing. The version is visible in the output of ``python3 setup.py bdist_wheel``, e.g:
 
 ``Copying src/docker_hostdns.egg-info to build/bdist.linux-x86_64/wheel/docker_hostdns-2.1.0-py3.4.egg-info``
 

--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,7 @@ Docker environment variables
 - ``DNS_ZONE``:              DNS zone to update, defaults to "docker"
 - ``DNS_KEY_SECRET``:        DNS Server key secret for use when updating zone
 - ``DNS_KEY_SECRET_FILE``:   path of file with secret as its content
+- ``CLEAR_ON_EXIT``:         clear zone on exit
 
 Securing DNS secret key
 ***********************

--- a/README.rst
+++ b/README.rst
@@ -99,8 +99,20 @@ For help try ``docker run --rm -it glorpen/hostdns:latest --help``.
 
 Remember to mount ``/run/docker.sock`` inside container.
 
-Docker Environment Variables
-============================
+Build image from GitHub
+***********************
+
+- ``git clone <repo>``
+- ``cd docker-hostdns/``
+- ``python3 setup.py bdist_wheel``
+- ``docker build -t "<image name>" --build-arg HOSTDNS_VERSION=<version> .``
+
+* <version> ``2.1.0`` is the latest at the time of writing. The version is visible in the output of ``python3 setup.py bdist_wheel``, e.g.:
+
+``Copying src/docker_hostdns.egg-info to build/bdist.linux-x86_64/wheel/docker_hostdns-2.1.0-py3.4.egg-info``
+
+Docker environment variables
+****************************
 
 - ``DNS_SERVER``:            IP address of DNS server which will be updated, defaults to 127.0.0.1
 - ``DNS_ZONE``:              DNS zone to update, defaults to "docker"

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,14 @@ For help try ``docker run --rm -it glorpen/hostdns:latest --help``.
 
 Remember to mount ``/run/docker.sock`` inside container.
 
+Docker Environment Variables
+============================
+
+- ``DNS_SERVER``:            IP address of DNS server which will be updated, defaults to 127.0.0.1
+- ``DNS_ZONE``:              DNS zone to update, defaults to "docker"
+- ``DNS_KEY_SECRET``:        DNS Server key secret for use when updating zone
+- ``DNS_KEY_SECRET_FILE``:   path of file with secret as its content
+
 Securing DNS secret key
 ***********************
 

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -25,4 +25,12 @@ if key_secret is None:
 if key_secret:
 	pre_args.extend(["--dns-key-secret", key_secret])
 
+dns_zone = os.environ.get("DNS_ZONE")
+if dns_zone:
+        pre_args.extend(["--zone", dns_zone])
+
+dns_server = os.environ.get("DNS_SERVER")
+if dns_server:
+        pre_args.extend(["--dns-server", dns_server])
+
 dconsole.execute([sys.argv[0]] + pre_args + app_args)

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -33,4 +33,8 @@ dns_server = os.environ.get("DNS_SERVER")
 if dns_server:
         pre_args.extend(["--dns-server", dns_server])
 
+clear_on_exit = os.environ.get("CLEAR_ON_EXIT")
+if clear_on_exit and clear_on_exit.lower() in ["true", "yes"]:
+	pre_args.extend(["--clear-on-exit"])
+
 dconsole.execute([sys.argv[0]] + pre_args + app_args)

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -10,7 +10,7 @@ import docker_hostdns.console as dconsole
 
 app_args = sys.argv[1:]
 
-if app_args[0][0] != "-":
+if len(sys.argv) > 1 and app_args[0][0] != "-":
 	os.execvp(app_args[0], app_args)
 
 pre_args = []


### PR DESCRIPTION
I find it simpler to use environment variables to set arguments for Docker container in Portainer than to specify them as part of the command. Although I was a bit lazy and only added the ones I wanted to use. :)

Wanting to run the container without arguments created a problem with ``if app_args[0][0] != "-":`` as well, which I think I've resolved.

Hopefully I've made this more usable off the command line without breaking anything on the command line.