### PR TITLE
Added all the arguments as environment variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,10 @@ Docker environment variables
 - ``DNS_KEY_NAME``:          DNS Server key name for use when updating zone
 - ``DNS_KEY_SECRET``:        DNS Server key secret for use when updating zone
 - ``DNS_KEY_SECRET_FILE``:   path of file with secret as its content
+- ``NAME``:		     name to differentiate between multiple instances inside same dns zone, defaults to current hostname
+- ``NETWORK``:		     network to fetch container names from, defaults to docker default bridge, accepts multiple networks as comma delimited list (e.g. ``network1,network2,network3,..``)
+- ``VERBOSITY``:	     give more output, accepts ``0`` to ``3``, defaults to ``0`` (equivalent to ``-v``, ``-vv``, ``-vvv`` arguments on the command line)
+- ``SYSLOG``:		     enable logging to syslog, defaults to ``false`` (accepts ``true`` or ``yes``)
 - ``CLEAR_ON_EXIT``:         clear zone on exit, defaults to ``false`` (accepts ``true`` or ``yes``)
 
 Securing DNS secret key

--- a/README.rst
+++ b/README.rst
@@ -114,11 +114,12 @@ Build image from GitHub
 Docker environment variables
 ****************************
 
-- ``DNS_SERVER``:            IP address of DNS server which will be updated, defaults to 127.0.0.1
-- ``DNS_ZONE``:              DNS zone to update, defaults to "docker"
+- ``DNS_SERVER``:            IP address of DNS server which will be updated, defaults to ``127.0.0.1``
+- ``DNS_ZONE``:              DNS zone to update, defaults to ``docker``
+- ``DNS_KEY_NAME``:          DNS Server key name for use when updating zone
 - ``DNS_KEY_SECRET``:        DNS Server key secret for use when updating zone
 - ``DNS_KEY_SECRET_FILE``:   path of file with secret as its content
-- ``CLEAR_ON_EXIT``:         clear zone on exit
+- ``CLEAR_ON_EXIT``:         clear zone on exit, defaults to ``false`` (accepts ``true`` or ``yes``)
 
 Securing DNS secret key
 ***********************

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -37,6 +37,35 @@ dns_server = os.environ.get("DNS_SERVER")
 if dns_server:
         pre_args.extend(["--dns-server", dns_server])
 
+instance_name = os.environ.get("NAME")
+if instance_name:
+	pre_args.extend(["--name", instance_name])
+
+network = os.environ.get("NETWORK")
+if network:
+        net_list = [x.strip() for x in network.split(',')]
+        for network in net_list:
+                pre_args.extend(["--network", network])
+
+verbosity = os.environ.get("VERBOSITY")
+if verbosity:
+        try:
+                verb_int = int(verbosity)
+        except ValueError:
+                verb_int = None
+
+        if verb_int:
+                verbosity = '-'
+                count = 0
+                for count in range(min(verb_int, 3)):
+                        verbosity += 'v'
+                        count += 1
+                pre_args.extend([verbosity])
+
+syslog = os.environ.get("SYSLOG")
+if syslog and syslog.lower() in ["true", "yes"]:
+	pre_args.extend(["--syslog"])
+
 clear_on_exit = os.environ.get("CLEAR_ON_EXIT")
 if clear_on_exit and clear_on_exit.lower() in ["true", "yes"]:
 	pre_args.extend(["--clear-on-exit"])

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+import argparse
 import docker_hostdns.console as dconsole
 
 app_args = sys.argv[1:]
@@ -13,7 +14,47 @@ app_args = sys.argv[1:]
 if len(sys.argv) > 1 and app_args[0][0] != "-":
 	os.execvp(app_args[0], app_args)
 
-pre_args = []
+env_conf = {}
+
+envs = [
+	(
+		{
+			"DNS_ZONE": "zone",
+			"DNS_KEY_NAME": "dns_key_name",
+			"NAME": "name",
+			"DNS_SERVER": "dns_server"
+		},
+		str
+	),
+	(
+		{
+			"SYSLOG": "syslog",
+			"CLEAR_ON_EXIT": "clear_on_exit"
+		},
+		lambda x: x.lower() in ["true", "yes", "1", "y"]
+	),
+	(
+		{
+			"NETWORK": "network"
+		},
+		lambda x: [y.strip() for y in x.split(',')]
+	),
+	(
+		{
+			"VERBOSITY": "verbose"
+		},
+		int
+	)
+]
+
+for env_list, value_normalizer in envs:
+	for env_name, conf_key in env_list.items():
+		value = os.environ.get(env_name)
+		if value:
+			try:
+				env_conf[conf_key] = value_normalizer(value)
+			except Exception as e:
+				raise Exception("Error on parsing %s: %r" % (env_name, value)) from e
 
 key_secret = os.environ.get("DNS_KEY_SECRET")
 if key_secret is None:
@@ -23,47 +64,8 @@ if key_secret is None:
 			key_secret = f.read()
 
 if key_secret:
-	pre_args.extend(["--dns-key-secret", key_secret])
+	env_conf["dns_key_secret"] = key_secret
 
-dns_key_name = os.environ.get("DNS_KEY_NAME")
-if dns_key_name:
-	pre_args.extend(["--dns-key-name", dns_key_name])
-
-dns_zone = os.environ.get("DNS_ZONE")
-if dns_zone:
-        pre_args.extend(["--zone", dns_zone])
-
-dns_server = os.environ.get("DNS_SERVER")
-if dns_server:
-        pre_args.extend(["--dns-server", dns_server])
-
-instance_name = os.environ.get("NAME")
-if instance_name:
-	pre_args.extend(["--name", instance_name])
-
-network = os.environ.get("NETWORK")
-if network:
-        net_list = [x.strip() for x in network.split(',')]
-        for network in net_list:
-                pre_args.extend(["--network", network])
-
-verbosity = os.environ.get("VERBOSITY")
-if verbosity:
-        try:
-                verb_int = int(verbosity)
-        except ValueError:
-                verb_int = None
-
-        if verb_int:
-                for count in range(min(verb_int, 3)):
-                        pre_args.extend(["-v"])
-
-syslog = os.environ.get("SYSLOG")
-if syslog and syslog.lower() in ["true", "yes"]:
-	pre_args.extend(["--syslog"])
-
-clear_on_exit = os.environ.get("CLEAR_ON_EXIT")
-if clear_on_exit and clear_on_exit.lower() in ["true", "yes"]:
-	pre_args.extend(["--clear-on-exit"])
-
-dconsole.execute([sys.argv[0]] + pre_args + app_args)
+conf = vars(dconsole.parse_commandline([sys.argv[0]] + app_args))
+conf.update(env_conf)
+dconsole.execute_with_configuration(argparse.Namespace(**conf))

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -55,12 +55,8 @@ if verbosity:
                 verb_int = None
 
         if verb_int:
-                verbosity = '-'
-                count = 0
                 for count in range(min(verb_int, 3)):
-                        verbosity += 'v'
-                        count += 1
-                pre_args.extend([verbosity])
+                        pre_args.extend(["-v"])
 
 syslog = os.environ.get("SYSLOG")
 if syslog and syslog.lower() in ["true", "yes"]:

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -25,6 +25,10 @@ if key_secret is None:
 if key_secret:
 	pre_args.extend(["--dns-key-secret", key_secret])
 
+dns_key_name = os.environ.get("DNS_KEY_NAME")
+if dns_key_name:
+	pre_args.extend(["--dns-key-name", dns_key_name])
+
 dns_zone = os.environ.get("DNS_ZONE")
 if dns_zone:
         pre_args.extend(["--zone", dns_zone])


### PR DESCRIPTION
Sorry, my last PR was premature it turns out. I realised I hadn't done ``--dns-key-name`` as an environment variable when I re-created my container in Portainer from scratch and everything stopped working. :) I spent way too long thinking I'd broken my BIND build before I realised what had happened. :) I must have had it set by the command and not realised.

I decided that, to make sure I wasn't premature again, I'd just do all the arguments as environmental variables whether I intend to use them or not.

I don't actually use Python very often, so I'm not sure if there's a better way to do the str->int casting and the iteration for ``--verbose``. It functions as expected in the testing I did though, so I was happy enough.

I don't know if ``--syslog`` actually does anything in the container mode..? I included it anyway in case I suddenly realised I needed it. I assumed it would be annoying if I did another PR tomorrow to add it in. :) It's easy enough to remove if it's not useful, just let me know.

The "Docker environment variables" section in the README is largely a cut and paste job, repeating a lot of information from further up the page. There are some things that need to be mentioned because the usage is slightly different (see ``VERBOSITY`` and ``NETWORK``) but maybe you'd prefer it if it wasn't so repetitive? I can work on that section, if you want.  Just let me know about any preferences you might have.